### PR TITLE
Updated graphql-ws library version

### DIFF
--- a/graphql/graphiql.html
+++ b/graphql/graphiql.html
@@ -182,8 +182,8 @@
       integrity="sha384-J66SJ/f9ysdOJbaOO8Hssim6BR6AfWfUWcPUNW8pfm1z+KJy9zPpfsI7HUoM/E5C" 
       crossorigin="anonymous">
     </script>    
-    <script src="https://unpkg.com/graphql-ws@5.5.5/umd/graphql-ws.min.js" 
-      integrity="sha384-iITzwBnP19J9MInXjdWTw6A1/9qUy+xLDGIvonjrGwa0HLsQUY82TN6UsY9xZlUo" 
+    <script src="https://unpkg.com/graphql-ws@5.11.2/umd/graphql-ws.min.js"
+      integrity="sha384-YCmZd4Ex7vwj0vv4QmS+tsx71Ld6zFIgOnyv0pBZ/5oRoZ4UCkPhL+MJ97ksrRiW"
       crossorigin="anonymous">
     </script>
     <script src="https://static.oracle.com/cdn/jet/11.0.0/3rdparty/require/require.js" integrity="sha384-Z9JQUtAaWmYKd6d4DNdwKbqQjtvpcd4f/QmJSoaDxeRg4hWHtyyF6BwCsrnLcG1F" crossorigin="anonymous"></script>


### PR DESCRIPTION
Upgraded version of graphql-ws library from 5.5.5 to 5.11.2.