### PR TITLE
Added DVM to the streaming schema

### DIFF
--- a/graphql/streaming/StreamingGraphQLSchema.json
+++ b/graphql/streaming/StreamingGraphQLSchema.json
@@ -628,6 +628,72 @@
             },
             {
                 "kind": "OBJECT",
+                "name": "DataValueMapping",
+                "description": "Data Value Mapping Type",
+                "fields": [
+                    {
+                        "name": "dataElement",
+                        "description": "The name of the mapped data element",
+                        "args": [
+
+                        ],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "operaValue",
+                        "description": "The original OPERA value",
+                        "args": [
+
+                        ],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "externalValue",
+                        "description": "The mapped external value",
+                        "args": [
+
+                        ],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [
+
+                ],
+                "enumValues": null,
+                "possibleTypes": null
+            },            {
+                "kind": "OBJECT",
                 "name": "EventHeader",
                 "description": "Event Header Type",
                 "fields": [
@@ -780,6 +846,24 @@
                                     "name": "EventDetail",
                                     "ofType": null
                                 }
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "dataValueMapping",
+                        "description": "Optional data value mappings for this event",
+                        "args": [
+
+                        ],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "DataValueMapping",
+                                "ofType": null
                             }
                         },
                         "isDeprecated": false,


### PR DESCRIPTION
Updated the streaming API's GraphQL schema to include the DVM (Data Value Mapping) fields now returned if "Enable DVM" is set on the external system in OPERA Cloud UI.