### PR TITLE
Updated R&A Data APIs GraphQL schemas to v26.2.

### DIFF
--- a/graphql/data-apis/ARAccountsReceivable.graphql
+++ b/graphql/data-apis/ARAccountsReceivable.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ARAccountsReceivable GraphQL API,
 # description : GraphQL API to cater for Detailed Accounts Receivable data, including  Adjustments, Payments, Invoices and Posting for AR Accounts, with linked reservation data.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ARAgingReport.graphql
+++ b/graphql/data-apis/ARAgingReport.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ARAgingReport GraphQL API,
 # description : GraphQL API to cater for Detailed information on accounts receivable transactions including aging bucket of invoices, open transaction amounts, folio information and the account details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2265,6 +2265,8 @@ type ARAgingReportFinancialTransactionDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""

--- a/graphql/data-apis/ARLedger.graphql
+++ b/graphql/data-apis/ARLedger.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ARLedger GraphQL API,
 # description : GraphQL API to cater for Ledger details showing activity in accounts receivables including reservation and transaction details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2813,6 +2813,8 @@ type ARLedgerReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -2863,6 +2865,8 @@ type ARLedgerReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""

--- a/graphql/data-apis/Activities.graphql
+++ b/graphql/data-apis/Activities.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA Activities GraphQL API,
 # description : GraphQL API to cater for Provides information of Sales activities related to Accounts, Contacts, and Blocks for the selected Property.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/BookingReservationExtended.graphql
+++ b/graphql/data-apis/BookingReservationExtended.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA BookingReservationExtended GraphQL API,
 # description : GraphQL API to cater for Provide booking reservation information with extended or additional details such as blocks, routing, etc.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2219,6 +2219,10 @@ type BookingReservationExtendedReservationUnifiedDetailsType {
   uDFC39: String
   """UDFC40"""
   uDFC40: String
+  """Reservation user defined date 01"""
+  uDFD01: Date
+  """Reservation user defined date 02"""
+  uDFD02: Date
   """Universal Card ID used by interfaces for key encoding purposes."""
   uniCardId: String
   """Upload Date"""
@@ -4531,6 +4535,8 @@ type BookingReservationExtendedReservationPaymentMethodsDetailsType {
   centralPaymentMethodType: String
   """Central Payment Method Type Description"""
   centralPaymentMethodTypeDescription: String
+  """Indicates whether the billing window is confidential or not."""
+  confidentialFolioYN: String
   """Credit Card Authorization Date"""
   creditCardAuthorizationDate: DateTime
   """Credit Card ID"""

--- a/graphql/data-apis/BookingsBlock.graphql
+++ b/graphql/data-apis/BookingsBlock.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA BookingsBlock GraphQL API,
 # description : GraphQL API to cater for Block header and grid details, including actual and potential room and revenue statistics, catering events, and the associated profile and reservations data.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -4418,6 +4418,8 @@ type BookingsBlockReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -4468,6 +4470,8 @@ type BookingsBlockReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -5708,6 +5712,8 @@ type BookingsBlockFinancialTransactionDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""

--- a/graphql/data-apis/BookingsBlockProductionChanges.graphql
+++ b/graphql/data-apis/BookingsBlockProductionChanges.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA BookingsBlockProductionChanges GraphQL API,
 # description : GraphQL API to cater for Detailed information on blocks and any changes to the number of rooms or revenue, by stay date, property and Block Owner.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/BookingsBlockStatusChanges.graphql
+++ b/graphql/data-apis/BookingsBlockStatusChanges.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA BookingsBlockStatusChanges GraphQL API,
 # description : GraphQL API to cater for Detailed information on the status changes throughout the production period of a block, including the new and old status codes, rooms and associated revenues, by property and Block Owner.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/BookingsReservation.graphql
+++ b/graphql/data-apis/BookingsReservation.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA BookingsReservation GraphQL API,
 # description : GraphQL API to cater for Detailed information on reservations booked in the past and future, including market code, rate code, reservation status, guest information and associated room and revenue details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2715,6 +2715,8 @@ type BookingsReservationReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -2765,6 +2767,8 @@ type BookingsReservationReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -7023,6 +7027,8 @@ type BookingsReservationRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -7067,6 +7073,8 @@ type BookingsReservationRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -7097,6 +7105,10 @@ type BookingsReservationRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""
@@ -7819,6 +7831,10 @@ type BookingsReservationReservationDetailDetailsType {
   externalReference: String
   """Extra Beds"""
   extraBeds: Float
+  """FB Revenue"""
+  fBRevenue: Float
+  """FB Revenue Tax"""
+  fBRevenueTax: Float
   """Fixed Rate YN"""
   fixedRateYN: String
   """Not used."""
@@ -7853,10 +7869,22 @@ type BookingsReservationReservationDetailDetailsType {
   membershipPoints: Float
   """Not used."""
   netRoomAmt: Float
+  """Offshore Rate Amount"""
+  offshoreRateAmount: Float
+  """Offshore Rate Code"""
+  offshoreRateCode: String
+  """Offshore Rate Currency"""
+  offshoreRateCurrency: String
   """Internal ID to uniquely identify the Organization"""
   organizationID: Float
+  """Channel Code"""
+  origin: String
   """Not used."""
   originalBaseRate: Float
+  """Other Revenue"""
+  otherRevenue: Float
+  """Other Revenue Tax"""
+  otherTax: Float
   """Not used."""
   packageAmt: Float
   """Physical Quantity"""
@@ -7867,10 +7895,14 @@ type BookingsReservationReservationDetailDetailsType {
   pkgTax: Float
   """Points"""
   points: Float
+  """Posting Interval"""
+  postingInterval: String
   """Internal Primary Key ID to uniquely identify the row"""
   primaryKeyID: Float
   """Code to uniquely identify the Property"""
   property: String
+  """Purpose of Stay"""
+  purposeOfStay: String
   """Quantity"""
   quantity: Float
   """Rate"""
@@ -7903,6 +7935,10 @@ type BookingsReservationReservationDetailDetailsType {
   roomCost: Float
   """Room Instructions"""
   roomInstructions: String
+  """Room Revenue"""
+  roomRevenue: Float
+  """Room Revenue Tax"""
+  roomRevenueTax: Float
   """Room Tax"""
   roomTax: Float
   """Room Type"""
@@ -8207,6 +8243,8 @@ type BookingsReservationReservationProductsDetailsType {
   organizationID: Float
   """Override Fixed Rate Y/N"""
   overrideFixedRateYn: String
+  """The package category linked to this package."""
+  packageCategory: String
   """Package Code"""
   packageCode: String
   """Package Description"""
@@ -9261,6 +9299,8 @@ type BookingsReservationReservationPaymentMethodsDetailsType {
   centralPaymentMethodType: String
   """Central Payment Method Type Description"""
   centralPaymentMethodTypeDescription: String
+  """Indicates whether the billing window is confidential or not."""
+  confidentialFolioYN: String
   """Credit Card Authorization Date"""
   creditCardAuthorizationDate: DateTime
   """Credit Card ID"""
@@ -11097,6 +11137,8 @@ type BookingsReservationLinkedReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -11147,6 +11189,8 @@ type BookingsReservationLinkedReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: Date
   """User id who reviewed the record."""
@@ -12435,6 +12479,8 @@ type BookingsReservationSharedReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -12485,6 +12531,8 @@ type BookingsReservationSharedReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: Date
   """User id who reviewed the record."""

--- a/graphql/data-apis/CateringEventForecast.graphql
+++ b/graphql/data-apis/CateringEventForecast.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA CateringEventForecast GraphQL API,
 # description : GraphQL API to cater for Event revenue forecast details for defined periods broken down by Event Type, Revenue Group and Revenue Type.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/CateringEventPostings.graphql
+++ b/graphql/data-apis/CateringEventPostings.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA CateringEventPostings GraphQL API,
 # description : GraphQL API to cater for Event posting details including revenues by property, Block, Event and Revenue groups.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -3060,6 +3060,8 @@ type CateringEventPostingsFinancialTransactionIncRevenueTaxDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""
@@ -3784,6 +3786,8 @@ type CateringEventPostingsFinancialTransactionExtraRevenueTaxDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""
@@ -4508,6 +4512,8 @@ type CateringEventPostingsFinancialTransactionSvcChargeIncRevDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""
@@ -5232,6 +5238,8 @@ type CateringEventPostingsFinancialTransactionSvcChargeExtraRevDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""

--- a/graphql/data-apis/CateringEventStatusChanges.graphql
+++ b/graphql/data-apis/CateringEventStatusChanges.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA CateringEventStatusChanges GraphQL API,
 # description : GraphQL API to cater for Detailed information on the status changes throughout the production period of an event, including the new and old status codes, change date, revenue and attendees. 
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/CateringEventTypes.graphql
+++ b/graphql/data-apis/CateringEventTypes.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA CateringEventTypes GraphQL API,
 # description : GraphQL API to cater for Event type definitions. 
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/CateringEventsAndResources.graphql
+++ b/graphql/data-apis/CateringEventsAndResources.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA CateringEventsAndResources GraphQL API,
 # description : GraphQL API to cater for Event and Block details including group profile information, menu, packages and revenues broken down by event type.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ChangesLog.graphql
+++ b/graphql/data-apis/ChangesLog.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ChangesLog GraphQL API,
 # description : GraphQL API to cater for Provides detailed information on actions and the users who completed the action, including date, time, activity type, and description. Also providing the capability to combine with reservation, block and profile data.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -1074,6 +1074,8 @@ type ChangesLogActionDetailsType {
   eventID: Float
   """Action Id."""
   financialActionId: Float
+  """Insert Date Time"""
+  insertDateTime: Date
   """Ip Address"""
   ipAddress: String
   """JRN Update Date"""
@@ -1902,6 +1904,8 @@ type ChangesLogReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -1952,6 +1956,8 @@ type ChangesLogReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""

--- a/graphql/data-apis/ConfigurationChain.graphql
+++ b/graphql/data-apis/ConfigurationChain.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ConfigurationChain GraphQL API,
 # description : GraphQL API to cater for The Chain Configuration Subject Area contains configuration/setting attributes from components such as Enterprise Administration, Financial Administration, Booking Administration and Client Relations Administration in OPERA.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -964,6 +964,8 @@ type ConfigurationChainMembershipTypeDetailsType {
   randomGenerationYN: String
   """Rank"""
   rank: Float
+  """Number of days from join date of new member till when referral can be added."""
+  referralPeriod: Float
   """Requalify on Upgrade YN"""
   requalifyOnUpgradeYN: String
   """Required on Stay Period YN"""

--- a/graphql/data-apis/ConfigurationResort.graphql
+++ b/graphql/data-apis/ConfigurationResort.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ConfigurationResort GraphQL API,
 # description : GraphQL API to cater for The Resort Configuration Subject Area contains configuration/setting attributes from components such as Enterprise Administration, Financial Administration, Booking Administration and Client Relations Administration in OPERA.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -4135,6 +4135,10 @@ type ConfigurationResortAirportDetailsType {
   primaryKeyID: Float
   """Property"""
   property: String
+  """Rna Insert Date."""
+  rnaInsertDate: Date
+  """Rna Update Date."""
+  rnaUpdateDate: Date
   """Sequence"""
   sequence: Float
   """Internal."""
@@ -13993,6 +13997,8 @@ type ConfigurationResortQualifyingRatesDetailsType {
   packageYn: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Points Discount Y/n."""
+  pointsDiscountYN: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""

--- a/graphql/data-apis/EFolio.graphql
+++ b/graphql/data-apis/EFolio.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA EFolio GraphQL API,
 # description : GraphQL API to cater for This subject area contains data for billing folio settlements to be used for exporting to an external system for efolios. 
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -6461,6 +6461,8 @@ type EFolioReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -6511,6 +6513,8 @@ type EFolioReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""

--- a/graphql/data-apis/ExportMappings.graphql
+++ b/graphql/data-apis/ExportMappings.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ExportMappings GraphQL API,
 # description : GraphQL API to cater for Provides detailed information of all configured external codes/values (i.e. general ledger codes) mapped to codes used in OPERA (i.e transaction codes, market codes). It contains a comprehensive set of data including, but not limited to, Mapping Type Code/Descriptions, Mapped To Code/Descriptions with other Mapping details such as Export Values by Property / Chain.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/FinancialCommissions.graphql
+++ b/graphql/data-apis/FinancialCommissions.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA FinancialCommissions GraphQL API,
 # description : GraphQL API to cater for Detailed information on the commissions module, including Reservation and Travel Agent profile information, with commission codes, amounts, payment activity and processing status. Commission information can be reported across all properties by Travel Agent and Source profiles, bank account, guest information and dates.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/FinancialDepositLedger.graphql
+++ b/graphql/data-apis/FinancialDepositLedger.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA FinancialDepositLedger GraphQL API,
 # description : GraphQL API to cater for Deposit ledger details including individual transactions, folio information, calendar and financial period and the reservation details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2613,6 +2613,8 @@ type FinancialDepositLedgerReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -2663,6 +2665,8 @@ type FinancialDepositLedgerReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""

--- a/graphql/data-apis/FinancialGuestLedger.graphql
+++ b/graphql/data-apis/FinancialGuestLedger.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA FinancialGuestLedger GraphQL API,
 # description : GraphQL API to cater for Guest ledger details including individual reservations, posted transaction details with debit and credit amounts.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2097,6 +2097,8 @@ type FinancialGuestLedgerReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -2147,6 +2149,8 @@ type FinancialGuestLedgerReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""

--- a/graphql/data-apis/FinancialTransactionCodes.graphql
+++ b/graphql/data-apis/FinancialTransactionCodes.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA FinancialTransactionCodes GraphQL API,
 # description : GraphQL API to cater for Transaction code header details including flags, group, and sub-group details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/FinancialTransactionDetails.graphql
+++ b/graphql/data-apis/FinancialTransactionDetails.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA FinancialTransactionDetails GraphQL API,
 # description : GraphQL API to cater for Detailed information on all posted transactions including net and gross amounts, currency, calendar and financial period, market and rate code.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2461,6 +2461,8 @@ type FinancialTransactionDetailsFinancialTransactionDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""
@@ -6961,6 +6963,8 @@ type FinancialTransactionDetailsRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -7005,6 +7009,8 @@ type FinancialTransactionDetailsRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -7035,6 +7041,10 @@ type FinancialTransactionDetailsRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""
@@ -8051,6 +8061,8 @@ type FinancialTransactionDetailsReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -8101,6 +8113,8 @@ type FinancialTransactionDetailsReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -10505,6 +10519,8 @@ type FinancialTransactionDetailsFromReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -10555,6 +10571,8 @@ type FinancialTransactionDetailsFromReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -11843,6 +11861,8 @@ type FinancialTransactionDetailsToReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -11893,6 +11913,8 @@ type FinancialTransactionDetailsToReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""

--- a/graphql/data-apis/FinancialTransactionDetailsExtended.graphql
+++ b/graphql/data-apis/FinancialTransactionDetailsExtended.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA FinancialTransactionDetailsExtended GraphQL API,
 # description : GraphQL API to cater for Provide financial transaction information with extended or additional details such as routing, cashiers, currency, etc.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -3029,6 +3029,8 @@ type FinancialTransactionDetailsExtendedFromReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -3079,6 +3081,8 @@ type FinancialTransactionDetailsExtendedFromReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -6185,6 +6189,8 @@ type FinancialTransactionDetailsExtendedToReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -6235,6 +6241,8 @@ type FinancialTransactionDetailsExtendedToReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -7627,6 +7635,10 @@ type FinancialTransactionDetailsExtendedReservationUnifiedDetailsType {
   uDFC39: String
   """UDFC40"""
   uDFC40: String
+  """Reservation user defined date 01"""
+  uDFD01: Date
+  """Reservation user defined date 02"""
+  uDFD02: Date
   """Universal Card ID used by interfaces for key encoding purposes."""
   uniCardId: String
   """Upload Date"""

--- a/graphql/data-apis/FinancialTransactionsSummary.graphql
+++ b/graphql/data-apis/FinancialTransactionsSummary.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA FinancialTransactionsSummary GraphQL API,
 # description : GraphQL API to cater for Summarized information on posted transactions including transaction group, sub group and codes, broken down by property and business date.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/IntegrationConfigurations.graphql
+++ b/graphql/data-apis/IntegrationConfigurations.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA IntegrationConfigurations GraphQL API,
 # description : GraphQL API to cater for Exchange Configurations data including External Systems, External Databases, Business Events, Interface Setup, Interface Controls and Interface Mappings.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -126,11 +126,11 @@ input IntegrationConfigurationsQueryArgumentsType {
   """External Value"""
   interfacealldetailsDetailsExtValue: StringInput
   """Interface Id"""
-  interfacealldetailsDetailsMapInterfaceId: StringInput
-  """Interface Id"""
   interfacealldetailsDetailsInterfaceId: StringInput
   """Interface Id"""
   interfacealldetailsDetailsSuInterfaceId: StringInput
+  """Interface Id"""
+  interfacealldetailsDetailsMapInterfaceId: StringInput
   """JRN Update Date and Time"""
   interfacealldetailsDetailsMapJrnUpdateDttm: DateInput
   """JRN Update Date and Time"""
@@ -156,9 +156,9 @@ input IntegrationConfigurationsQueryArgumentsType {
   """Action Type"""
   extdbbuseventDetailsActionType: StringInput
   """DSI"""
-  extdbbuseventDetailsDsi: FloatInput
-  """DSI"""
   extdbbuseventDetailsEdDsi: FloatInput
+  """DSI"""
+  extdbbuseventDetailsDsi: FloatInput
   """Data Element"""
   extdbbuseventDetailsDataElement: StringInput
   """External Database"""

--- a/graphql/data-apis/InventoryFunctionSpaces.graphql
+++ b/graphql/data-apis/InventoryFunctionSpaces.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA InventoryFunctionSpaces GraphQL API,
 # description : GraphQL API to cater for All Function Space Details and Configured Options Including Room Type, Occupancy, Function Type, Room Setup, Notes and Physical Dimensions.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/InventoryHousekeepingManagementRoom.graphql
+++ b/graphql/data-apis/InventoryHousekeepingManagementRoom.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA InventoryHousekeepingManagementRoom GraphQL API,
 # description : GraphQL API to cater for Details on Tasks, Task Sheets and Credits and providing Information on Rooms, Room Attributes and Statuses for the current date.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/InventoryHousekeepingManagementTaskSheet.graphql
+++ b/graphql/data-apis/InventoryHousekeepingManagementTaskSheet.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA InventoryHousekeepingManagementTaskSheet GraphQL API,
 # description : GraphQL API to cater for Details on Tasks, Task Sheets and Credits for the current date.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/InventoryRooms.graphql
+++ b/graphql/data-apis/InventoryRooms.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA InventoryRooms GraphQL API,
 # description : GraphQL API to cater for Comprehensive Information on Guest Room Details and Configuration.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/InventoryRoomsManagement.graphql
+++ b/graphql/data-apis/InventoryRoomsManagement.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA InventoryRoomsManagement GraphQL API,
 # description : GraphQL API to cater for Provides detailed information on room maintenance and out of order/service assignments broken down by property, time and room dimensions. Also provides reservations and profile details for service requests.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ProfilesAccounts.graphql
+++ b/graphql/data-apis/ProfilesAccounts.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesAccounts GraphQL API,
 # description : GraphQL API to cater for The Profiles-Accounts subject area contains Account Room Night and Revenue statistics broken down between Group and Individual stays and can be summarized by Property, Stay Date, Business Segment, Owner and Profile Type.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ProfilesAddresses.graphql
+++ b/graphql/data-apis/ProfilesAddresses.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesAddresses GraphQL API,
 # description : GraphQL API to cater for All associated addresses including primary and secondary addresses, and address types which can be associated with the proper profile and profile type.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ProfilesCommunications.graphql
+++ b/graphql/data-apis/ProfilesCommunications.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesCommunications GraphQL API,
 # description : GraphQL API to cater for All associated communication details including communication types and roles, which can be associated with the proper profile and profile type. 
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ProfilesContacts.graphql
+++ b/graphql/data-apis/ProfilesContacts.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesContacts GraphQL API,
 # description : GraphQL API to cater for The Contacts subject area contains Room Night and Revenue statistics broken down between booked and stays reservations and can be summarized by Property, Stay Date, Business Segment and Owner.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -1976,6 +1976,10 @@ type ProfilesContactsProfileMembershipDetailsType {
   profileid: Float
   """Current membership ranking value for this profile possible values: 1-10."""
   ranking: Float
+  """Number of times a new member has been referred."""
+  referralCount: Float
+  """Name ID of member who referred."""
+  referredByMember: String
   """RnA Insertdate"""
   rnaInsertDate: DateTime
   """RnA Updatedate"""

--- a/graphql/data-apis/ProfilesIndividuals.graphql
+++ b/graphql/data-apis/ProfilesIndividuals.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesIndividuals GraphQL API,
 # description : GraphQL API to cater for Guest profile data including contact information, VIP codes, memberships and stay statistics with room and revenue details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2114,6 +2114,10 @@ type ProfilesIndividualsProfileMembershipDetailsType {
   profileid: Float
   """Current membership ranking value for this profile possible values: 1-10."""
   ranking: Float
+  """Number of times a new member has been referred."""
+  referralCount: Float
+  """Name ID of member who referred."""
+  referredByMember: String
   """RnA Insertdate"""
   rnaInsertDate: DateTime
   """RnA Updatedate"""

--- a/graphql/data-apis/ProfilesLoyalty.graphql
+++ b/graphql/data-apis/ProfilesLoyalty.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesLoyalty GraphQL API,
 # description : GraphQL API to cater for Detailed information on the Loyalty Program providing details on the Membership, Profiles, Stay Information and the ability to  track Awards and Claims.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -606,6 +606,10 @@ type ProfilesLoyaltyLoyaltyProfileMembershipDetailsType {
   rankValue: Float
   """Ranking"""
   ranking: Float
+  """Number of times a new member has been referred."""
+  referralCount: Float
+  """Name ID of member who referred."""
+  referredByMember: String
   """RnA Insertdate"""
   rnaInsertDate: DateTime
   """RnA Updatedate"""
@@ -1204,6 +1208,8 @@ type ProfilesLoyaltyMembershipTransactionsDetailsType {
   recordTypeDescription: String
   """Reference"""
   reference: String
+  """Name ID of member referred."""
+  referredMember: String
   """Reservation Name ID"""
   reservationNameID: Float
   """Reservation Status"""

--- a/graphql/data-apis/ProfilesLoyaltyClaims.graphql
+++ b/graphql/data-apis/ProfilesLoyaltyClaims.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesLoyaltyClaims GraphQL API,
 # description : GraphQL API to cater for Detailed information on the Loyalty Program providing details on the Membership, Profiles, Stay Information and the ability to track Claims.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -681,6 +681,8 @@ type ProfilesLoyaltyClaimsRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -725,6 +727,8 @@ type ProfilesLoyaltyClaimsRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -755,6 +759,10 @@ type ProfilesLoyaltyClaimsRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""

--- a/graphql/data-apis/ProfilesLoyaltyTransactions.graphql
+++ b/graphql/data-apis/ProfilesLoyaltyTransactions.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesLoyaltyTransactions GraphQL API,
 # description : GraphQL API to cater for Detailed information on the Loyalty Program providing details on the Membership, Profiles, Stay Information and the ability to track Awards.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -976,6 +976,8 @@ type ProfilesLoyaltyTransactionsMembershipTransactionsDetailsType {
   recordTypeDescription: String
   """Reference"""
   reference: String
+  """Name ID of member referred."""
+  referredMember: String
   """Reservation Name ID"""
   reservationNameID: Float
   """Reservation Status"""
@@ -1262,6 +1264,10 @@ type ProfilesLoyaltyTransactionsLoyaltyProfileMembershipDetailsType {
   rankValue: Float
   """Ranking"""
   ranking: Float
+  """Number of times a new member has been referred."""
+  referralCount: Float
+  """Name ID of member who referred."""
+  referredByMember: String
   """RnA Insertdate"""
   rnaInsertDate: DateTime
   """RnA Updatedate"""

--- a/graphql/data-apis/ProfilesMembershipTransactions.graphql
+++ b/graphql/data-apis/ProfilesMembershipTransactions.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesMembershipTransactions GraphQL API,
 # description : GraphQL API to cater for Provides information on Stay Records statistics of guest stay and its respective Membership Transactions details for a profile.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -500,6 +500,8 @@ type ProfilesMembershipTransactionsMembershipTransactionsDetailsType {
   recordTypeDescription: String
   """Reference"""
   reference: String
+  """Name ID of member referred."""
+  referredMember: String
   """Reservation Name ID"""
   reservationNameID: Float
   """Reservation Status"""

--- a/graphql/data-apis/ProfilesNotes.graphql
+++ b/graphql/data-apis/ProfilesNotes.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesNotes GraphQL API,
 # description : GraphQL API to cater for Profile note types and note details, including internal and confidential flags, and the profile details they are associated with.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ProfilesRelationshipTypes.graphql
+++ b/graphql/data-apis/ProfilesRelationshipTypes.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesRelationshipTypes GraphQL API,
 # description : GraphQL API to cater for Relationship type definition.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ProfilesRelationships.graphql
+++ b/graphql/data-apis/ProfilesRelationships.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesRelationships GraphQL API,
 # description : GraphQL API to cater for The Profile - Relationships subject area contains relationship details including the relationship type, description and role and the profiles that are linked through the relationship.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ProfilesStayRecords.graphql
+++ b/graphql/data-apis/ProfilesStayRecords.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ProfilesStayRecords GraphQL API,
 # description : GraphQL API to cater for Provides information on Stay Records statistics of guest stay and its respective Membership Transactions details for a profile.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -781,6 +781,8 @@ type ProfilesStayRecordsMembershipTransactionsDetailsType {
   recordTypeDescription: String
   """Reference"""
   reference: String
+  """Name ID of member referred."""
+  referredMember: String
   """Reservation Name ID"""
   reservationNameID: Float
   """Reservation Status"""

--- a/graphql/data-apis/PromotionCouponCodes.graphql
+++ b/graphql/data-apis/PromotionCouponCodes.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA PromotionCouponCodes GraphQL API,
 # description : GraphQL API to cater for Promotion Coupon Codes details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/Property.graphql
+++ b/graphql/data-apis/Property.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA Property GraphQL API,
 # description : GraphQL API to cater for Property definition with marketing, financial, and housekeeping details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesBuckets.graphql
+++ b/graphql/data-apis/RatesBuckets.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesBuckets GraphQL API,
 # description : GraphQL API to cater for Rate bucket definition.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesCategories.graphql
+++ b/graphql/data-apis/RatesCategories.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesCategories GraphQL API,
 # description : GraphQL API to cater for Rate category definition including begin and end date and rate class association.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesClasses.graphql
+++ b/graphql/data-apis/RatesClasses.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesClasses GraphQL API,
 # description : GraphQL API to cater for Rate class definition with begin and end date.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesCodeDetails.graphql
+++ b/graphql/data-apis/RatesCodeDetails.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesCodeDetails GraphQL API,
 # description : GraphQL API to cater for Rate Header information including room types, package elements, market and source code and associated flags.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -1912,6 +1912,8 @@ type RatesCodeDetailsRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -1956,6 +1958,8 @@ type RatesCodeDetailsRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -1986,6 +1990,10 @@ type RatesCodeDetailsRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""

--- a/graphql/data-apis/RatesCodes.graphql
+++ b/graphql/data-apis/RatesCodes.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesCodes GraphQL API,
 # description : GraphQL API to cater for Rate detail information including all rate header details,  room type, rate tiers and rate amounts per occupant.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -1156,6 +1156,8 @@ type RatesCodesRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -1200,6 +1202,8 @@ type RatesCodesRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -1230,6 +1234,10 @@ type RatesCodesRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""
@@ -4032,6 +4040,8 @@ type RatesCodesFinancialTransactionDetailsType {
   sourceGroupDescription: String
   """Source Group Display Sequence"""
   sourceGroupDisplaySequence: Float
+  """Source Resort where the transaction originates for cross posted transaction"""
+  sourceResort: String
   """Sourceid"""
   sourceid: String
   """Stores the type of split performed: [A]mount [Q]uantity [P]ercent."""

--- a/graphql/data-apis/RatesDepositAndCancellationRules.graphql
+++ b/graphql/data-apis/RatesDepositAndCancellationRules.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesDepositAndCancellationRules GraphQL API,
 # description : GraphQL API to cater for Deposit and cancellation rules schedules and details by date, rate code and days prior to arrival or after booking.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesHurdles.graphql
+++ b/graphql/data-apis/RatesHurdles.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesHurdles GraphQL API,
 # description : GraphQL API to cater for Rate yielding and hurdle information including date, amount , length of stay and room type.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesRateSeasons.graphql
+++ b/graphql/data-apis/RatesRateSeasons.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesRateSeasons GraphQL API,
 # description : GraphQL API to cater for Rate yielding and hurdle information including date, amount , length of stay and room type.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesRestrictions.graphql
+++ b/graphql/data-apis/RatesRestrictions.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesRestrictions GraphQL API,
 # description : GraphQL API to cater for Rate restriction definition including restriction type, date applied, room and rate code with day of the week and length of the stay details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RatesTiers.graphql
+++ b/graphql/data-apis/RatesTiers.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RatesTiers GraphQL API,
 # description : GraphQL API to cater for Rate tier definition by length of stays.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/ResortBudgetForecast.graphql
+++ b/graphql/data-apis/ResortBudgetForecast.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA ResortBudgetForecast GraphQL API,
 # description : GraphQL API to cater for This Subject Area Contains the Budget Forecast Details of the Property(s).
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RevenueFixedCharges.graphql
+++ b/graphql/data-apis/RevenueFixedCharges.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RevenueFixedCharges GraphQL API,
 # description : GraphQL API to cater for Details on fixed charges including amount, frequency, and transaction code and the linked reservations.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2170,6 +2170,8 @@ type RevenueFixedChargesReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -2220,6 +2222,8 @@ type RevenueFixedChargesReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""

--- a/graphql/data-apis/RevenueGroupsAndTypes.graphql
+++ b/graphql/data-apis/RevenueGroupsAndTypes.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RevenueGroupsAndTypes GraphQL API,
 # description : GraphQL API to cater for Revenue group and type details.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/RevenuePackages.graphql
+++ b/graphql/data-apis/RevenuePackages.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA RevenuePackages GraphQL API,
 # description : GraphQL API to cater for Package header details including package group setup and associated flags for selling and consumption options.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/SalesManagerGoals.graphql
+++ b/graphql/data-apis/SalesManagerGoals.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA SalesManagerGoals GraphQL API,
 # description : GraphQL API to cater for The Sales Manager Goals subject Area enable the end users to retrieve information / create reports to compare the goals set for the Sales Managers against completed activities, and against statistical revenue data associated to profiles.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/SimpleReportsActivities.graphql
+++ b/graphql/data-apis/SimpleReportsActivities.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA SimpleReportsActivities GraphQL API,
 # description : GraphQL API to cater for The Simple Report Activities Subject Area simplifies creating and building adhoc reports, including the ability to create new reports.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/SimpleReportsBookingBlocks.graphql
+++ b/graphql/data-apis/SimpleReportsBookingBlocks.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA SimpleReportsBookingBlocks GraphQL API,
 # description : GraphQL API to cater for The Simple Reports Booking Blocks Subject Area simplifies creating and building adhoc reports, including the ability to create new reports.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/SimpleReportsBookingsReservation.graphql
+++ b/graphql/data-apis/SimpleReportsBookingsReservation.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA SimpleReportsBookingsReservation GraphQL API,
 # description : GraphQL API to cater for The Simple Reports Bookings Reservation Subject Area simplifies creating and building adhoc reports, including the ability to create new reports.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/SimpleReportsEvents.graphql
+++ b/graphql/data-apis/SimpleReportsEvents.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA SimpleReportsEvents GraphQL API,
 # description : GraphQL API to cater for The Simple Reports Events Subject Area simplifies creating and building adhoc reports, including the ability to create new reports.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/SimpleReportsFinancialTransactions.graphql
+++ b/graphql/data-apis/SimpleReportsFinancialTransactions.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA SimpleReportsFinancialTransactions GraphQL API,
 # description : GraphQL API to cater for The Simple Reports Financial Transactions Subject Area simplifies creating and building adhoc reports, including the ability to create new reports.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/SimpleReportsProfileIndividuals.graphql
+++ b/graphql/data-apis/SimpleReportsProfileIndividuals.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA SimpleReportsProfileIndividuals GraphQL API,
 # description : GraphQL API to cater for The Simple Reports Profile-Individuals Subject Area simplifies creating and building adhoc reports, including the ability to create new reports.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/StatisticsForecastSummary.graphql
+++ b/graphql/data-apis/StatisticsForecastSummary.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA StatisticsForecastSummary GraphQL API,
 # description : GraphQL API to cater for Future on the books information including rooms, revenue and persons with breakdowns by room types, market code, source code and periods of time.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -3639,6 +3639,8 @@ type StatisticsForecastSummaryRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -3683,6 +3685,8 @@ type StatisticsForecastSummaryRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -3713,6 +3717,10 @@ type StatisticsForecastSummaryRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""

--- a/graphql/data-apis/StatisticsHistoryAndForecast.graphql
+++ b/graphql/data-apis/StatisticsHistoryAndForecast.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA StatisticsHistoryAndForecast GraphQL API,
 # description : GraphQL API to cater for Detailed information on past and future reservations including occupancy and revenue figures with all profile data, broken down by Market, Rate code, Room type and Periods of time.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/StatisticsManagersReport.graphql
+++ b/graphql/data-apis/StatisticsManagersReport.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA StatisticsManagersReport GraphQL API,
 # description : GraphQL API to cater for Past statistics including rooms and revenue figures, arrivals, departures and occupancy broken out by multiple time periods.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl

--- a/graphql/data-apis/StatisticsReservationPace.graphql
+++ b/graphql/data-apis/StatisticsReservationPace.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA StatisticsReservationPace GraphQL API,
 # description : GraphQL API to cater for The Reservation Pace subject area contains daily rooms and revenue information on reservations on the books as of specific dates in the past (snapshot dates) summarized by Property, PACERATECODE, Room Type, Channel and Rate Code.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -910,6 +910,8 @@ type StatisticsReservationPacePaceRateCodeDetailsType {
   pkgTransactionCode: String
   """Package Transaction Code Wk"""
   pkgTransactionCodeWk: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
   """Number of nights for posting rhythm."""
   postingRhythmNights: Float
   """Posting Rhythum"""

--- a/graphql/data-apis/StatisticsReservationsDaily.graphql
+++ b/graphql/data-apis/StatisticsReservationsDaily.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA StatisticsReservationsDaily GraphQL API,
 # description : GraphQL API to cater for Detailed information on past reservations including occupancy and revenue figures with all profile data, broken down by Market, Rate code, room type and periods of time.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -4199,6 +4199,8 @@ type StatisticsReservationsDailyReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -4249,6 +4251,8 @@ type StatisticsReservationsDailyReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -6669,6 +6673,8 @@ type StatisticsReservationsDailyRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -6713,6 +6719,8 @@ type StatisticsReservationsDailyRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -6743,6 +6751,10 @@ type StatisticsReservationsDailyRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""
@@ -9163,6 +9175,8 @@ type StatisticsReservationsDailyReservationStatisticsDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -9213,6 +9227,8 @@ type StatisticsReservationsDailyReservationStatisticsDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: Date
   """User id who reviewed the record."""

--- a/graphql/data-apis/StatisticsReservationsDailySummary.graphql
+++ b/graphql/data-apis/StatisticsReservationsDailySummary.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA StatisticsReservationsDailySummary GraphQL API,
 # description : GraphQL API to cater for Summarized information on past reservations including number of persons, rooms and revenue figures, broken down by room type, market code, rate code and periods of time.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -2193,6 +2193,8 @@ type StatisticsReservationsDailySummaryRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -2237,6 +2239,8 @@ type StatisticsReservationsDailySummaryRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -2267,6 +2271,10 @@ type StatisticsReservationsDailySummaryRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""

--- a/graphql/data-apis/StatisticsReservationsSummary.graphql
+++ b/graphql/data-apis/StatisticsReservationsSummary.graphql
@@ -1,10 +1,10 @@
 
 # title : OPERA Cloud RnA StatisticsReservationsSummary GraphQL API,
 # description : GraphQL API to cater for Summarized booking data for both on the books and past stays including rooms, revenue and occupancy details broken out by Market Code, Rate code and periods of time.
-#               Compatible with OPERA Cloud RnA release 26.1.0.0.
+#               Compatible with OPERA Cloud RnA release 26.2.0.0.
 #               This document and all content within is available under the Universal Permissive License v 1.0 
 #               (https://oss.oracle.com/licenses/upl). Copyright (c) 2020,2026 Oracle and/or its affiliates
-# version : 26.1.0.0
+# version : 26.2.0.0
 # termsOfService : https://www.oracle.com/legal/terms.html
 # contact_email : hospitality_apis_ww_grp@oracle.com
 # license : https://opensource.org/licenses/upl
@@ -3109,6 +3109,8 @@ type StatisticsReservationsSummaryReservationDetailsType {
   packageForecastGroup: String
   """Package Forecast Group Description"""
   packageForecastGroupDescription: String
+  """Parent Org Code"""
+  parentOrgCode: String
   """Parent Resv Name ID"""
   parentReservationNameId: Float
   """Parentreservationid"""
@@ -3159,6 +3161,8 @@ type StatisticsReservationsSummaryReservationDetailsType {
   postStayChargingYN: String
   """Posting Allowed YN"""
   postingAllowedYN: String
+  """Posting Interval"""
+  postingInterval: String
   """This date flags if and when the record was reviewed from pre-arrival screen."""
   preArrReviewedDt: DateTime
   """User id who reviewed the record."""
@@ -5029,6 +5033,8 @@ type StatisticsReservationsSummaryRateCodeDetailsType {
   jRNUpdateDate: Date
   """JRN Update Date and Time"""
   jRNUpdateDateAndTime: DateTime
+  """Local rate code associated with offshore rate code."""
+  localRateCode: String
   """Internal ID to uniquely identify the Property"""
   locationID: String
   """Long Info"""
@@ -5073,6 +5079,8 @@ type StatisticsReservationsSummaryRateCodeDetailsType {
   occupancyBasedYn: String
   """Indicates the occupancy level for hurdle evaluation."""
   occupancyLevel: Float
+  """Indicates if rate code is an offshore rate."""
+  offshoreRateYN: String
   """The operator type to use during the calculation of base rates. (ADD_TO SUBTRACT)"""
   operatorType: String
   """Order By"""
@@ -5103,6 +5111,10 @@ type StatisticsReservationsSummaryRateCodeDetailsType {
   packages: String
   """Indicates whether the rate code is pending for approval or not"""
   pendingApprovalYn: String
+  """Allow users to use points to get discount on rate codes."""
+  pointsDiscountYN: String
+  """Posting Interval."""
+  postingInterval: String
   """Posting Rhythm"""
   postingRhythm: String
   """Number of nights for posting rhythm."""

--- a/graphql/data-apis/base.graphql
+++ b/graphql/data-apis/base.graphql
@@ -1,6 +1,8 @@
 # This is the base graphql schema which is used to build federated graph
 
 directive @stream(if: Boolean, label: String, initialCount: Int = 0) on FIELD
+directive @conditionalInputPair(pair: Int) on INPUT_FIELD_DEFINITION
+directive @mandatoryInput on INPUT_FIELD_DEFINITION
 scalar Date
 scalar DateTime
 input DateInput{


### PR DESCRIPTION
Data APIs 26.2 specifications added. See [release notes](https://docs.oracle.com/en/industries/hospitality/opera-reporting-analytics/rnora/c_feature_summary.htm) and [resolved issues](https://docs.oracle.com/en/industries/hospitality/opera-reporting-analytics/rnora/c_resolved_issues.htm).